### PR TITLE
Add MythTVServicesAPI as a requirement via GitHub URL, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,6 @@ This component is a media_player entity, and therefore will try to implement as 
 ### Prerequisites
 [Home Assistant](https://home-assistant.io) installed and operational.  Installation using a [VirtualEnv](https://home-assistant.io/docs/installation/virtualenv/) or [Hassbian](https://home-assistant.io/docs/hassbian/installation/) on Raspberry Pi is recommended and installation instructions are based on this method.
 
-[MythTVServicesAPI Utilities](https://github.com/billmeek/MythTVServicesAPI) 
-
-### Installing MythTVServicesAPI
-*NOTE: If you installed the the API prior to May 4, 2017, remove the old ```/srv/homeassistant/lib/python3.5/site-packages/MythTVServicesAPI``` directory prior to installing the new version via pip.*
-
-Add MythTVServicesAPI to your Python3.5/site-packages folder. If using VirtualEnv or Hassbian, switch to your homeassistant user and enter the VirtualEnv by performing the following commands:
-```
-sudo su -s /bin/bash homeassistant
-source /srv/homeassistant/bin/activate
-```
-Next, install the API:
-```
-pip install https://raw.githubusercontent.com/billmeek/MythTVServicesAPI/master/dist/mythtv_services_api-0.0.3-py3-none-any.whl
-```
-
 ### Installing mythfrontend.py custom component
 In the Home Assistant configuration directory (located at ```/home/homeassistant/.homeassistant``` for VirtualEnv/Hassbian installs), make sure ```/custom_components/media_player``` exists.  If it does not exist, perform the following:
 ```
@@ -34,7 +19,8 @@ mkdir -p custom_components/media_player
 cd custom_components/media_player
 wget https://raw.githubusercontent.com/calmor15014/HA-Component-mythtv-frontend/master/mythfrontend.py
 ```
-This makes the required custom media_player folder and copies the ```mythfrontend.py``` file from this repository to the new folder.
+This makes the required custom media_player folder and copies the ```mythfrontend.py``` file from this repository to the new folder.  
+When you first run Home Assistant after this, it will install the MythTVServicesAPI requirement.
 
 ## Adding and Configuring a MythTV Frontend in Home Assistant
 

--- a/mythfrontend.py
+++ b/mythfrontend.py
@@ -19,9 +19,11 @@ from homeassistant.const import (
     CONF_MAC, STATE_PLAYING, STATE_IDLE, STATE_PAUSED)
 import homeassistant.helpers.config_validation as cv
 
-# TODO add MythTVServicesAPI if/when added to pip
 # WOL requirement for turn_on
-REQUIREMENTS = ['wakeonlan==0.2.2']
+REQUIREMENTS = ['wakeonlan==0.2.2',
+                'https://github.com/billmeek/MythTVServicesAPI/archive/'
+                '691a1b0fa7028b4222c04d280d1823b565759ab0.zip'
+                '#mythtv_services_api==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I found out how to use `REQUIREMENTS` to install the MythTVServicesAPI from GitHub.
https://home-assistant.io/developers/code_review_platform/#1-requirements doesn't explain it well (I'll edit this doc one day), but this works :)