### PR TITLE
Add backend host as part of configuration, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ In your ```configuration.yaml``` file, add the following:
 ```
 media_player:
   - platform: mythfrontend
-    host: (hostname or IP address)
-    name: Friendly frontend name (optional, default: MythTV Frontend)
+    host: Frontend hostname or IP address
     port: Frontend API services port (optional, default: 6547)
+    host_backend: Backend hostname or IP address (optional, defaults to same as host)
     port_backend: Backend API services port (optional, default: 6544)
-    show_artwork: Choose whether or not to show artwork (optional, default: True)
+    name: Friendly frontend name (optional, default: MythTV Frontend)
     mac: MAC address for WOL (optional)
+    show_artwork: Choose whether or not to show artwork (optional, default: True)
 ```
 Note - if using IPv6, use the format ```"[::]"``` replacing ```::``` with your full IPv6 address.  ```host``` also takes hostnames if they can be resolved by DNS.
 


### PR DESCRIPTION
Closes #17 
I've chosen to keep `host` and `port` in the config (YAML) and add the more specific `host_backend` and `port_backend`, rather than also changing to `host_frontend`, but internally (Python) I've renamed them to be specific. 
Perhaps it's better to have the config specific as well, but I don't know. This seems fine to me.
Tested with my combined system with and without specifying the backend config.