### PR TITLE
First attempt at shutdown function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ ENV/
 
 # IDE settings
 .idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This component is a media_player entity, and therefore will try to implement as 
 ### Prerequisites
 [Home Assistant](https://home-assistant.io) installed and operational.  Installation using a [VirtualEnv](https://home-assistant.io/docs/installation/virtualenv/) or [Hassbian](https://home-assistant.io/docs/hassbian/installation/) on Raspberry Pi is recommended and installation instructions are based on this method.
 
-[MythTVServicesAPI Utilities](https://github.com/billmeek/MythTVServicesAPI) 
+[MythTVServicesAPI Utilities](https://github.com/billmeek/MythTVServicesAPI)
 
 ### Installing MythTVServicesAPI
 
@@ -50,12 +50,13 @@ media_player:
     name: Friendly frontend name (optional, default: MythTV Frontend)
     mac: MAC address for WOL (optional)
     show_artwork: Choose whether or not to show artwork (optional, default: True)
+    shutdown_key_event: System Key Event number (1-10) to trigger for frontend device shutdown (optional, default: None)
 ```
-Note - if using IPv6, use the format ```"[::]"``` replacing ```::``` with your full IPv6 address.  ```host``` also takes hostnames if they can be resolved by DNS.
+Note - if using an IPv6 host, use the format ```"[::]"``` replacing ```::``` with your full IPv6 address.  ```host``` also takes hostnames if they can be resolved by DNS.
 
 ## Notes
 
-* MythTV Services API in version 0.29-pre appears to have a broken implementation of SendAction, so this version may not respond correctly to frontend actions.  0.28-fixes has been tested to work normally.  If the frontend status is indicated, but controls do not work, please post on the [Home Assistant development thread](https://community.home-assistant.io/t/adding-mythtv-frontend-component/16991) with your MythTV version.
+* MythTV Services API in version 29-pre appears to have a broken implementation of SendAction, so this version may not respond correctly to frontend actions.  0.28-fixes has been tested to work normally.  If the frontend status is indicated, but controls do not work, please post on the [Home Assistant development thread](https://community.home-assistant.io/t/adding-mythtv-frontend-component/16991) with your MythTV version.
 
 ## Acknowledgements
 

--- a/mythfrontend.py
+++ b/mythfrontend.py
@@ -56,6 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_MAC): cv.string,
     vol.Optional('show_artwork', default=DEFAULT_ARTWORK_CHOICE): cv.boolean,
+    vol.Optional('shutdown_key_event'): cv.positive_int,
 })
 
 
@@ -69,10 +70,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     mac = config.get(CONF_MAC)
     show_artwork = config.get('show_artwork')
+    shutdown_key_event = config.get('shutdown_key_event')
 
     add_devices([MythTVFrontendDevice(host_frontend, port_frontend,
                                       host_backend, port_backend, name, mac,
-                                      show_artwork)])
+                                      show_artwork, shutdown_key_event)])
     _LOGGER.info("MythTV Frontend %s:%d added as '%s' with backend %s:%s",
                  host_frontend, port_frontend, name, host_backend,
                  port_backend)
@@ -82,7 +84,7 @@ class MythTVFrontendDevice(MediaPlayerDevice):
     """Representation of a MythTV Frontend."""
 
     def __init__(self, host_frontend, port_frontend, host_backend,
-                 port_backend, name, mac, show_artwork):
+                 port_backend, name, mac, show_artwork, shutdown_key_event):
         """Initialize the MythTV API."""
         from mythtv_services_api import send as api
         from wakeonlan import wol
@@ -101,6 +103,7 @@ class MythTVFrontendDevice(MediaPlayerDevice):
         self._state = STATE_UNKNOWN
         self._last_playing_title = None
         self._media_image_url = None
+        self._shutdown_key_event = shutdown_key_event
 
     def update(self):
         """Retrieve the latest data."""
@@ -255,7 +258,11 @@ class MythTVFrontendDevice(MediaPlayerDevice):
             # Add WOL feature
             features |= SUPPORT_TURN_ON
         if self._volume['control']:
+            # Add volume control features
             features |= SUPPORT_VOLUME_CONTROL
+        if self._shutdown_key_event:
+            # Add system power off feature
+            features |= SUPPORT_TURN_OFF
         return features
 
     @property
@@ -350,3 +357,8 @@ class MythTVFrontendDevice(MediaPlayerDevice):
         """Turn the media player on."""
         if self._mac:
             self._wol.send_magic_packet(self._mac)
+
+    def turn_off(self):
+        """Turn the frontend device off."""
+        if self._shutdown_key_event:
+            self.api_send_action(action='SYSEVENT%02d' % self._shutdown_key_event)


### PR DESCRIPTION
Adds a configuration item to indicate which System Key Event to fire to shut off the frontend device.  Requires that System Key Event to be set up to shut down the device.