### PR TITLE
Implement frontend discovery through Myth/GetFrontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Home Assistant component for MythTV 0.27+ Frontend
 ## About This Component
 This component is being developed to allow Home Assistant to interact with a MythTV frontend using the MythTV API Service (available in MythTV version 0.27 and later).  It will work with a frontend-only or combination frontend and backend machine.  This component currently only adds frontend services. Future updates may provide interfaces with the backend.
 
-This component contains a *media_player* entity, and therefore will try to implement as many of the media_player funcitons including play/pause, volume control, and chapter controls.  
+This component contains a *media_player* entity, and therefore will try to implement as many of the media_player functions including play/pause, volume control, and chapter controls.  
+
 It also provides a *notify* service so you can send messages to your MythTV frontend.
 
 ## Getting Started
@@ -14,20 +15,16 @@ It also provides a *notify* service so you can send messages to your MythTV fron
 - [Home Assistant](https://home-assistant.io) installed and operational.  
 Installation using a [VirtualEnv](https://home-assistant.io/docs/installation/virtualenv/) or [Hassbian](https://home-assistant.io/docs/hassbian/installation/) on Raspberry Pi is recommended and installation instructions are based on this method.
 
-- [MythTVServicesAPI Utilities](https://github.com/billmeek/MythTVServicesAPI)
+### Installing MythTV Services API
 
-### Installing MythTVServicesAPI
-
-Add MythTVServicesAPI to your Python3.x/site-packages folder. If using VirtualEnv or Hassbian, switch to your homeassistant user and enter the VirtualEnv by performing the following commands (depending on how you have installed Home Assistant):
+Add MythTVServicesAPI to your Python3.x/site-packages folder. If using VirtualEnv or Hassbian, switch to your homeassistant user and enter the VirtualEnv by performing the following commands (depending on how you have installed Home Assistant).  
+Next, install the API:
 ```
 sudo su -s /bin/bash homeassistant
 source /srv/homeassistant/bin/activate
+pip install -i https://test.pypi.org/simple/ mythtvservicesapi
+exit
 ```
-Next, install the API (check https://github.com/billmeek/MythTVServicesAPI/tree/master/dist for the latest version and adjust this command to match):
-```
-pip install https://raw.githubusercontent.com/billmeek/MythTVServicesAPI/master/dist/mythtv_services_api-0.1.9-py3-none-any.whl
-```
-
 
 ### Installing MythTV as a custom component
 In the Home Assistant configuration directory (usually located at `/home/homeassistant/.homeassistant` for VirtualEnv/Hassbian installs), install this component using something like the following (adjust to suit your system):

--- a/mythtv/__init__.py
+++ b/mythtv/__init__.py
@@ -59,7 +59,7 @@ def setup(hass, config):
 class MythTVBackend:
     def __init__(self, host, port):
         # Import MythTV API for communications
-        from mythtv_services_api import send as api
+        from mythtvservicesapi import send as api
 
         self._be = api.Send(host=host, port=port)
 

--- a/mythtv/__init__.py
+++ b/mythtv/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.event import call_later
 
-from .const import DOMAIN
+from .const import DOMAIN, MYTHTV_ID
 
 # Set default port for backend configuration
 DEFAULT_PORT = 6544
@@ -141,6 +141,7 @@ class MythTVBackend:
                     CONF_HOST: val["IP"],
                     CONF_PORT: val["Port"],
                     CONF_NAME: val["Name"],
+                    MYTHTV_ID: val["Name"],
                 }
                 load_platform(self.hass, MP_DOMAIN, DOMAIN, discovery_info, self.config)
 

--- a/mythtv/const.py
+++ b/mythtv/const.py
@@ -1,3 +1,4 @@
 """Constants for MythTV integration."""
 # Set the domain name for the integration
 DOMAIN = "mythtv"
+MYTHTV_ID = "mythtv_id"

--- a/mythtv/const.py
+++ b/mythtv/const.py
@@ -1,0 +1,3 @@
+"""Constants for MythTV integration."""
+# Set the domain name for the integration
+DOMAIN = "mythtv"

--- a/mythtv/media_player.py
+++ b/mythtv/media_player.py
@@ -5,8 +5,6 @@ Support for interface with a MythTV Frontend.
 # https://github.com/calmor15014/HA-Component-mythtv-frontend/
 """
 import logging
-import subprocess
-import sys
 
 from mythtvservicesapi import send as api
 import voluptuous as vol
@@ -102,6 +100,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
     }
 )
+
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Setup the MythTV Frontend platform."""
@@ -168,71 +168,52 @@ class MythTVFrontendEntity(MediaPlayerEntity):
         self._fe = api.Send(host=host_frontend, port=port_frontend)
         self._turn_off = turn_off
         self._timeout = timeout
+        self._connected = True
 
     def update(self):
-        """Retrieve the latest data."""
-        return self.api_update()
-
-    def api_update(self):
         """Use the API to get the latest status."""
         _LOGGER.debug("MythTVFrontendEntity.api_update()")
-        try:
-            result = self._fe.send(
-                endpoint="Frontend/GetStatus", opts={"timeout": self._timeout}
-            )
+        if self._connected:  # only update connected players
+            try:
+                result = self._fe.send(
+                    endpoint="Frontend/GetStatus", opts={"timeout": self._timeout}
+                )
 
-            if list(result.keys())[0] in ["Abort", "Warning"]:
-                # Remove volume controls while frontend is unavailable
-                self._volume["control"] = False
-
-                # If ping succeeds but API fails, MythFrontend state is unknown
-                if self._ping_host():
+                if list(result.keys())[0] in ["Abort", "Warning"]:
+                    # If frontend is connected but API fails, MythFrontend state is unknown
+                    self.available = False
                     self._state = STATE_UNKNOWN
-                # If ping fails also, MythFrontend is off/unreachable
+                    return False
+
+                # Make frontend status values more user-friendly
+                self._frontend = result["FrontendStatus"]["State"]
+
+                # Determine state of frontend
+                if self._frontend["state"] == "idle":
+                    self._state = STATE_IDLE
+                elif self._frontend["state"].startswith("Watching"):
+                    if self._frontend["playspeed"] == "0":
+                        self._state = STATE_PAUSED
+                    else:
+                        self._state = STATE_PLAYING
                 else:
-                    self._state = STATE_OFF
+                    self._state = STATE_ON
+
+                # only get artwork from backend if the playing media has changed
+                if self._state not in [STATE_PLAYING, STATE_PAUSED]:
+                    self._media_image_url = None
+                elif self._show_artwork and self._has_playing_media_changed():
+                    self._media_image_url = self._get_artwork()
+
+            except RuntimeError as error:
+                # It is possible this frontend went offline since the last GetFrontends poll
+                self._mythtv._get_frontends()
+
+                # Log error if frontend is not off
+                if self._state != STATE_OFF:
+                    _LOGGER.warning("Error with '%s' - %s", self._name, error)
+
                 return False
-
-            # Make frontend status values more user-friendly
-            self._frontend = result["FrontendStatus"]["State"]
-
-            # Determine state of frontend
-            if self._frontend["state"] == "idle":
-                self._state = STATE_IDLE
-            elif self._frontend["state"].startswith("Watching"):
-                if self._frontend["playspeed"] == "0":
-                    self._state = STATE_PAUSED
-                else:
-                    self._state = STATE_PLAYING
-            else:
-                self._state = STATE_ON
-
-            # Set volume control flag and level if the volume tag is present
-            if "volume" in self._frontend:
-                self._volume["control"] = True
-                self._volume["level"] = int(self._frontend["volume"])
-            # Set mute status if mute tag exists
-            if "mute" in self._frontend:
-                self._volume["muted"] = self._frontend["mute"] != "0"
-
-            # only get artwork from backend if the playing media has changed
-            if self._state not in [STATE_PLAYING, STATE_PAUSED]:
-                self._media_image_url = None
-            elif self._show_artwork and self._has_playing_media_changed():
-                self._media_image_url = self._get_artwork()
-
-        except RuntimeError as error:
-            # Log only if we don't already know the system is off/unreachable
-            if self._state != STATE_OFF and self._state != STATE_UNKNOWN:
-                _LOGGER.warning("Error with '%s' - %s", self._name, error)
-
-            # Use ping to set status
-            if self._ping_host():
-                self._state = STATE_UNKNOWN
-            # If ping fails also, MythFrontend is off/unreachable
-            else:
-                self._state = STATE_OFF
-            return False
 
         return True
 
@@ -245,27 +226,6 @@ class MythTVFrontendEntity(MediaPlayerEntity):
             channel_id = self._frontend.get("chanid")
             return self._mythtv.recording_artwork(start_time, channel_id)
 
-    # Reference: device_tracker/ping.py
-    def _ping_host(self):
-        """Ping the host to see if API status has some errors."""
-        if sys.platform == "win32":
-            ping_cmd = ["ping", "-n 1", "-w 1000", self._host_frontend]
-        else:
-            ping_cmd = ["ping", "-nq", "-c1", "-W1", self._host_frontend]
-        pinger = subprocess.Popen(
-            ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-        )
-        try:
-            pinger.communicate()
-            return pinger.returncode == 0
-        except subprocess.CalledProcessError:
-            _LOGGER.warning(
-                "MythFrontend ping error for '%s' at '%s'",
-                self._name,
-                self._host_frontend,
-            )
-            return False
-
     def api_send_action(self, action, value=None):
         """Send a command to the Frontend."""
         try:
@@ -274,7 +234,7 @@ class MythTVFrontendEntity(MediaPlayerEntity):
                 postdata={"Action": action, "Value": value},
                 opts={"wrmi": True, "timeout": self._timeout},
             )
-            self.api_update()
+            self.update()
         except OSError:
             self._state = STATE_OFF
             return False
@@ -294,6 +254,35 @@ class MythTVFrontendEntity(MediaPlayerEntity):
     def state(self):
         """Return the state of the entity."""
         return self._state
+
+    @property
+    def connected(self):
+        """Return True if entity connected to backend."""
+        return self._connected
+
+    @connected.setter
+    def connected(self, connected):
+        """Set connected attributed and make related changes to entity."""
+        self._connected = connected
+
+        if connected:
+            # Set volume control flag and level if the volume tag is present
+            if "volume" in self._frontend:
+                self._volume["control"] = True
+                self._volume["level"] = int(self._frontend["volume"])
+
+            # Set mute status if mute tag exists
+            if "mute" in self._frontend:
+                self._volume["muted"] = self._frontend["mute"] != "0"
+
+            # Update state of newly connected frontend
+            self.update()
+        else:
+            # Remove volume controls while frontend is unavailable
+            self._volume["control"] = False
+
+            # Disconnected frontends are 'off'
+            self._state = STATE_OFF
 
     @property
     def volume_level(self):

--- a/mythtv/media_player.py
+++ b/mythtv/media_player.py
@@ -41,7 +41,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import DOMAIN, MYTHTV_ID
 
 # Prerequisite (to be converted to standard PyPI library when available)
 # https://github.com/billmeek/MythTVServicesAPI
@@ -92,6 +92,7 @@ FRONTEND_SCHEMA = {
     vol.Optional(CONF_PORT, default=DEFAULT_PORT_FRONTEND): cv.port,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_MAC): cv.string,
+    vol.Optional(MYTHTV_ID): cv.string,
     vol.Optional("show_artwork", default=DEFAULT_ARTWORK_CHOICE): cv.boolean,
     vol.Optional(
         CONF_TURN_OFF_SYSEVENT, default=DEFAULT_TURN_OFF_SYSEVENT
@@ -125,6 +126,7 @@ def setup_platform(hass, conf, add_entities, discovery_info=None):
         turn_off = config.get(CONF_TURN_OFF_SYSEVENT)
     else:
         turn_off = "none"
+    mythtv_id = config.get(MYTHTV_ID)
 
     frontend = MythTVFrontendEntity(
         host_frontend,
@@ -135,6 +137,7 @@ def setup_platform(hass, conf, add_entities, discovery_info=None):
         show_artwork,
         turn_off,
         timeout,
+        mythtv_id,
     )
     add_entities([frontend], True)  # update entity immediately to set unique_id
 
@@ -156,6 +159,7 @@ class MythTVFrontendEntity(MediaPlayerEntity):
         show_artwork,
         turn_off,
         timeout,
+        mythtv_id,
     ):
         """Initialize the MythTV API."""
 
@@ -176,7 +180,7 @@ class MythTVFrontendEntity(MediaPlayerEntity):
         self._turn_off = turn_off
         self._timeout = timeout
         self._connected = True
-        self._unique_id = None
+        self._unique_id = mythtv_id
 
     def update(self):
         """Use the API to get the latest status."""

--- a/mythtv/media_player.py
+++ b/mythtv/media_player.py
@@ -8,7 +8,7 @@ import logging
 import subprocess
 import sys
 
-from mythtv_services_api import send as api
+from mythtvservicesapi import send as api
 import voluptuous as vol
 import wakeonlan
 

--- a/mythtv/notify.py
+++ b/mythtv/notify.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/notify.mythfrontend (but not yet)
 import asyncio
 import logging
 
-from mythtv_services_api import send as api
+from mythtvservicesapi import send as api
 import voluptuous as vol
 
 from homeassistant.components.notify import (


### PR DESCRIPTION
An initial attempt to implement frontend discovery through Myth/GetFrontend, fixing issue #43. Based on `issue37` branch because it needs a separate frontend and backend object. I also merged in PR #46.

I've made some changes to the separation of frontend and backend; in particular, I didn't understand why there were two different backend/API objects.

This needs more testing (and likely discussion) before being merged.