### PR TITLE
Fix tracking of disconnected frontends

### DIFF
--- a/mythtv/__init__.py
+++ b/mythtv/__init__.py
@@ -84,7 +84,7 @@ class MythTVBackend:
         self.config = config
 
         # create a dictionary of frontends.
-        # Myth/GetFrontend has no uuid, so we use "IP" as key
+        # Myth/GetFrontend has no uuid, so we use "Name" as key
         self._frontends = {}
 
         self._cancel_discovery = None
@@ -180,6 +180,13 @@ class MythTVBackend:
         for frontend in response["FrontendList"]["Frontends"]:
             frontend_dict[frontend["Name"]] = frontend
         return frontend_dict
+
+    def add_frontend(self, frontend):
+        """Add a frontend to dictionary of known frontends."""
+        if frontend.unique_id:
+            self._frontends.update({frontend.unique_id: frontend})
+        else:
+            _LOGGER.debug("Could not track frontend %s, no unique_id")
 
 # pylint: disable=unused-argument
     def _discovery(self, now=None):

--- a/mythtv/__init__.py
+++ b/mythtv/__init__.py
@@ -127,13 +127,6 @@ class MythTVBackend:
         art = self.__call_API(endpoint)
         return self.__process_art_response("Program", art)
 
-    # def get_frontends(self):
-    #     result = self.__call_API("Myth/GetFrontends")
-    #     if "Frontends" in result["FrontendList"]:
-    #         return result["FrontendList"]["Frontends"]
-    #     else:
-    #         return None
-
     def __get_tuners(self):
         result = self.__call_API("Dvr/GetEncoderList")
         if "Encoders" in result["EncoderList"]:
@@ -141,16 +134,6 @@ class MythTVBackend:
         else:
             return None
 
-    # def get_online_status(self, frontend):
-    #     frontends = self.backend.get_frontends()
-    #     if frontends is None:
-    #         return False
-    #     else:
-    #         for fe in frontends:
-    #             if frontend == fe["Name"] or frontend == fe["IP"]:
-    #                 return fe["OnLine"] == "1"
-    #         return False
-        
     def get_tuners(self):
         tuners = self.__get_tuners()
         response = []
@@ -173,6 +156,7 @@ class MythTVBackend:
                     if input["DisplayName"] == tuner_name:
                         return connected
         return False
+
     def _get_frontends(self):
         """Get frontends with "Name" as key."""
         response = self.__call_API("Myth/GetFrontends?OnLine=1")

--- a/mythtv/media_player.py
+++ b/mythtv/media_player.py
@@ -140,6 +140,7 @@ def setup_platform(hass, conf, add_entities, discovery_info=None):
         mythtv_id,
     )
     add_entities([frontend], True)  # update entity immediately to set unique_id
+    mythtv.add_frontend(frontend)
 
     _LOGGER.info(
         "MythTV Frontend %s:%d added as '%s'", host_frontend, port_frontend, name,
@@ -222,8 +223,9 @@ class MythTVFrontendEntity(MediaPlayerEntity):
                     self._media_image_url = self._get_artwork()
 
             except RuntimeError as error:
-                # It is possible this frontend went offline since the last GetFrontends poll
-                self._mythtv._get_frontends()
+                # Mark frontends that error as disconnected. They will be rediscovered by
+                # Myth/GetFrontends if they come online.
+                self.connected = False
 
                 # Log error if frontend is not off
                 if self._state != STATE_OFF:

--- a/mythtv/media_player.py
+++ b/mythtv/media_player.py
@@ -238,11 +238,11 @@ class MythTVFrontendEntity(MediaPlayerEntity):
     def _get_artwork(self):
         # Get artwork from backend using video file or starttime and chanid
         if self._frontend.get("state") == "WatchingVideo":
-            return self._mythtv.backend.get_video_artwork(self._frontend.get("pathname"))
+            return self._mythtv.get_video_artwork(self._frontend.get("pathname"))
         else:
             start_time = self._frontend.get("starttime").strip("Z")
             channel_id = self._frontend.get("chanid")
-            return self._mythtv.backend.get_recording_artwork(start_time, channel_id)
+            return self._mythtv.get_recording_artwork(start_time, channel_id)
 
     def api_send_action(self, action, value=None):
         """Send a command to the Frontend."""


### PR DESCRIPTION
There were two errors in my discovery code. First, we weren't actually adding frontends to list of known frontends when they were added to Home Assistant. As a result, we weren't marking disconnected frontends as such.

Second, we should mark frontends that error on update as disconnected. Otherwise, if we have a frontend that doesn't have a unique id (set up in `configuration.yaml` without a `mythtv_tv`), the discovery process has no way to know it is disconnected and we will spam the network and logs with failed connection attempts.